### PR TITLE
Fix broken relation tooltip

### DIFF
--- a/Advanced Character Search/gui/acs_character_presentation_top.gui
+++ b/Advanced Character Search/gui/acs_character_presentation_top.gui
@@ -49,7 +49,7 @@ types acs_character_presentation_top_types {
                 text = "[Character.GetUINameNoTooltip]"
                 autoresize = no
                 fontsize_min = 9.99
-                tooltip = "[Character.GetCharacterRelationCombine( GetPlayer )] [Character.GetUINameNoTooltip]"
+                tooltip = "[Character.GetRelationToString( GetPlayer )] [Character.GetUINameNoTooltip]"
             }
 
             hbox = {


### PR DESCRIPTION
It looks like one instance of a deprecated command was overlooked. Found through the error.log.